### PR TITLE
🐛 Fix KeyError 'network_latency' in generate_plots.py

### DIFF
--- a/analysis/scripts/generate_plots.py
+++ b/analysis/scripts/generate_plots.py
@@ -36,7 +36,7 @@ class MonteCarloPlotter:
         scatter = ax.scatter(
             self.df['tx_rate'],
             self.df['block_size'],
-            c=self.df['network_latency'],
+            c=self.df['latency_avg'],
             cmap='viridis',
             alpha=0.6,
             s=50,


### PR DESCRIPTION
### Problem
The plot generation script (`generate_plots.py`) raised a `KeyError: 'network_latency'` because the column is absent in the input performance CSVs.

### Solution
The reference to the missing column has been replaced with the available and relevant column, `'latency_avg'` (Average Transaction Latency), to correctly color the scatter plot.

✅ Ready for review.