### PR TITLE
Fix failing tests in bccsp/hybrid package

### DIFF
--- a/bccsp/hybrid/hybrid.go
+++ b/bccsp/hybrid/hybrid.go
@@ -1,3 +1,4 @@
+// hybrid.go
 package hybrid
 
 import (

--- a/bccsp/hybrid/key.go
+++ b/bccsp/hybrid/key.go
@@ -1,3 +1,4 @@
+// key.go
 package hybrid
 
 import (

--- a/bccsp/hybrid/pqc_signer.go
+++ b/bccsp/hybrid/pqc_signer.go
@@ -6,8 +6,8 @@ import (
 	"github.com/open-quantum-safe/liboqs-go/oqs"
 )
 
-// PQCAlgorithm da usare
-const PQCAlgorithm = "Dilithium2"
+// PQCAlgorithm da usare - ML-DSA-65 è il nome standard NIST per Dilithium3
+const PQCAlgorithm = "ML-DSA-65"
 
 // PQCSigner wrap del signer PQC
 type PQCSigner struct {
@@ -25,6 +25,7 @@ func NewPQCSigner() (*PQCSigner, error) {
 	// Genera la coppia di chiavi
 	pubKey, err := signer.GenerateKeyPair()
 	if err != nil {
+		signer.Clean()
 		return nil, fmt.Errorf("failed to generate key pair: %w", err)
 	}
 	
@@ -66,4 +67,9 @@ func (p *PQCSigner) Verify(msg, sig []byte) (bool, error) {
 // PublicKey restituisce la chiave pubblica
 func (p *PQCSigner) PublicKey() []byte {
 	return p.publicKey
+}
+
+// Clean libera le risorse
+func (p *PQCSigner) Clean() {
+	p.signer.Clean()
 }

--- a/bccsp/hybrid/pqc_signer.go
+++ b/bccsp/hybrid/pqc_signer.go
@@ -1,3 +1,4 @@
+// ./bccsp/hybrid/pqc_signer.go
 package hybrid
 
 import (

--- a/bccsp/hybrid/sign.go
+++ b/bccsp/hybrid/sign.go
@@ -1,3 +1,4 @@
+// ./bccsp/hybrid/sign.go
 package hybrid
 
 import (

--- a/bccsp/hybrid/verify.go
+++ b/bccsp/hybrid/verify.go
@@ -1,8 +1,10 @@
+// ./bccsp/hybrid/verify.go
 package hybrid
 
 import (
 	"fmt"
 	"github.com/hyperledger/fabric-lib-go/bccsp"
+	"github.com/open-quantum-safe/liboqs-go/oqs"
 )
 
 // Verify verifica la firma ibrida
@@ -12,8 +14,21 @@ func (h *HybridBCCSP) Verify(k bccsp.Key, signature, digest []byte, opts bccsp.S
 		return false, fmt.Errorf("invalid key type, expected *hybridKey")
 	}
 	
-	// PQC verification con gestione errore
-	valid, err := key.pqcPriv.Verify(digest, signature)
+	// Verifica che abbiamo la chiave pubblica PQC
+	if len(key.pqcPub) == 0 {
+		return false, fmt.Errorf("PQC public key is empty")
+	}
+	
+	// Crea un verifier PQC temporaneo per la verifica
+	// (la verifica richiede solo la chiave pubblica)
+	signer := oqs.Signature{}
+	if err := signer.Init(PQCAlgorithm, nil); err != nil {
+		return false, fmt.Errorf("failed to init PQC verifier: %w", err)
+	}
+	defer signer.Clean()
+	
+	// PQC verification usando la chiave pubblica
+	valid, err := signer.Verify(digest, signature, key.pqcPub)
 	if err != nil {
 		return false, fmt.Errorf("PQC verification failed: %w", err)
 	}


### PR DESCRIPTION
Some tests in the bccsp/hybrid package are failing, potentially indicating issues with key generation, signature verification, public key handling, and the PQC signer implementation.